### PR TITLE
Implement GcWeak

### DIFF
--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -211,6 +211,9 @@ impl Context {
                             work_done += sweep_size as f64;
                             self.allocation_debt
                                 .set((self.allocation_debt.get() - sweep_size as f64).max(0.0));
+                            if let Some(alive_flag) = sweep.alive_flag.as_ref() {
+                                alive_flag.set(false);
+                            }
                             Box::from_raw(sweep_ptr.as_ptr());
                         } else {
                             // If the next object in the sweep portion of the main list is black, we
@@ -282,6 +285,7 @@ impl Context {
             uninitialized.as_mut_ptr(),
             GcBox {
                 flags: flags,
+                alive_flag: None,
                 next: Cell::new(self.all.get()),
                 value: UnsafeCell::new(t),
             },

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -55,7 +55,7 @@ pub struct Context {
     remembered_size: Cell<usize>,
     wakeup_total: Cell<usize>,
     allocation_debt: Cell<f64>,
-    sweep_id: Cell<usize>,
+    sweep_id: Cell<u64>,
 
     all: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
     sweep: Cell<Option<NonNull<GcBox<dyn Collect>>>>,

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -187,7 +187,8 @@ impl Context {
                     } else {
                         // If we have no objects left in the normal gray queue, we enter the sweep
                         // phase.
-                        self.sweep_id.set(self.sweep_id.get() + 1);
+                        self.sweep_id
+                            .set(self.sweep_id.get().checked_add(1).expect("GC overflow"));
                         self.phase.set(Phase::Sweep);
                         self.sweep.set(self.all.get());
                     }

--- a/src/gc-arena/src/context.rs
+++ b/src/gc-arena/src/context.rs
@@ -371,6 +371,10 @@ impl Context {
         }
     }
 
+    /// Determines whether or not a Gc pointer is safe to be upgraded.
+    /// This is used by weak pointers to determine if it can safely upgrade to a strong pointer.
+    ///
+    /// Safety: `ptr` must be a valid pointer to a GcBox<T>.
     unsafe fn upgrade<T: Collect>(&self, ptr: NonNull<GcBox<T>>) -> bool {
         let gc_box = ptr.as_ref();
 

--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -1,5 +1,3 @@
-use alloc::rc::Rc;
-use core::cell::Cell;
 use core::fmt::{self, Debug};
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -60,19 +58,8 @@ impl<'gc, T: 'gc + Collect> Gc<'gc, T> {
         }
     }
 
-    pub fn downgrade(mut this: Gc<'gc, T>) -> GcWeak<'gc, T> {
-        unsafe {
-            let alive_flag = this
-                .ptr
-                .as_mut()
-                .alive_flag
-                .get_or_insert_with(|| Rc::new(Cell::new(true)));
-
-            GcWeak {
-                alive: alive_flag.clone(),
-                inner: this,
-            }
-        }
+    pub fn downgrade(this: Gc<'gc, T>) -> GcWeak<'gc, T> {
+        GcWeak { inner: this }
     }
 
     /// When implementing `Collect` on types with internal mutability containing `Gc` pointers, this

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -42,6 +42,10 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
         ))
     }
 
+    pub(crate) unsafe fn get_inner(&self) -> Gc<'gc, GcRefCell<T>> {
+        self.0
+    }
+
     pub fn ptr_eq(this: GcCell<'gc, T>, other: GcCell<'gc, T>) -> bool {
         this.as_ptr() == other.as_ptr()
     }
@@ -76,7 +80,7 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
     }
 }
 
-struct GcRefCell<T: Collect> {
+pub(crate) struct GcRefCell<T: Collect> {
     cell: RefCell<T>,
 }
 

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -4,6 +4,7 @@ use core::fmt::{self, Debug};
 use crate::collect::Collect;
 use crate::context::{CollectionContext, MutationContext};
 use crate::gc::Gc;
+use crate::GcWeakCell;
 
 /// A garbage collected pointer to a type T that may be safely mutated.  When a type that may hold
 /// `Gc` pointers is mutated, it may adopt new `Gc` pointers, and in order for this to be safe this
@@ -40,6 +41,10 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
                 cell: RefCell::new(t),
             },
         ))
+    }
+
+    pub fn downgrade(this: GcCell<'gc, T>) -> GcWeakCell<'gc, T> {
+        GcWeakCell { inner: this }
     }
 
     pub(crate) unsafe fn get_inner(&self) -> Gc<'gc, GcRefCell<T>> {

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -1,5 +1,6 @@
 use crate::collect::Collect;
 use crate::gc::Gc;
+use crate::types::GcColor;
 use crate::{CollectionContext, MutationContext};
 
 use core::fmt::{self, Debug};
@@ -27,7 +28,9 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
         unsafe {
             let gc = self.inner.ptr.as_ref();
             gc.flags.set_has_weak_ref(true);
-            gc.flags.set_freshly_allocated(false);
+            if gc.flags.color() == GcColor::FreshWhite {
+                gc.flags.set_color(GcColor::White);
+            }
         }
     }
 }

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -12,7 +12,7 @@ impl<'gc, T: Collect + 'gc> Copy for GcWeak<'gc, T> {}
 
 impl<'gc, T: Collect + 'gc> Clone for GcWeak<'gc, T> {
     fn clone(&self) -> GcWeak<'gc, T> {
-        Self { inner: self.inner }
+        *self
     }
 }
 

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -1,0 +1,42 @@
+use crate::collect::Collect;
+use crate::gc::Gc;
+
+use alloc::rc::Rc;
+use core::cell::Cell;
+use core::fmt::{self, Debug};
+
+pub struct GcWeak<'gc, T: 'gc + Collect> {
+    pub(crate) alive: Rc<Cell<bool>>,
+    pub(crate) inner: Gc<'gc, T>,
+}
+
+impl<'gc, T: Collect + 'gc> Clone for GcWeak<'gc, T> {
+    fn clone(&self) -> GcWeak<'gc, T> {
+        Self {
+            alive: self.alive.clone(),
+            inner: self.inner,
+        }
+    }
+}
+
+impl<'gc, T: 'gc + Collect> Debug for GcWeak<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "(GcWeak)")
+    }
+}
+
+unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
+    fn needs_trace() -> bool {
+        false
+    }
+}
+
+impl<'gc, T: Collect + 'gc> GcWeak<'gc, T> {
+    pub fn upgrade(&self) -> Option<Gc<'gc, T>> {
+        if !self.alive.get() {
+            return None;
+        }
+
+        Some(self.inner.clone())
+    }
+}

--- a/src/gc-arena/src/gc_weak.rs
+++ b/src/gc-arena/src/gc_weak.rs
@@ -25,7 +25,9 @@ impl<'gc, T: 'gc + Collect> Debug for GcWeak<'gc, T> {
 unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeak<'gc, T> {
     fn trace(&self, _cc: CollectionContext) {
         unsafe {
-            self.inner.ptr.as_ref().flags.set_has_weak_ref(true);
+            let gc = self.inner.ptr.as_ref();
+            gc.flags.set_has_weak_ref(true);
+            gc.flags.set_freshly_allocated(false);
         }
     }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -1,5 +1,5 @@
-use crate::collect::Collect;
 use crate::GcCell;
+use crate::{collect::Collect, MutationContext};
 
 use core::fmt::{self, Debug};
 
@@ -35,15 +35,7 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
 }
 
 impl<'gc, T: Collect + 'gc> GcWeakCell<'gc, T> {
-    pub fn upgrade(&self) -> Option<GcCell<'gc, T>> {
-        unsafe {
-            self.inner
-                .get_inner()
-                .ptr
-                .as_ref()
-                .flags
-                .alive()
-                .then(|| self.inner)
-        }
+    pub fn upgrade(&self, mc: MutationContext<'gc, '_>) -> Option<GcCell<'gc, T>> {
+        unsafe { mc.upgrade(self.inner.get_inner().ptr).then(|| self.inner) }
     }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -1,0 +1,49 @@
+use crate::collect::Collect;
+use crate::GcCell;
+
+use core::fmt::{self, Debug};
+
+pub struct GcWeakCell<'gc, T: 'gc + Collect> {
+    pub(crate) inner: GcCell<'gc, T>,
+}
+
+impl<'gc, T: Collect + 'gc> Copy for GcWeakCell<'gc, T> {}
+
+impl<'gc, T: Collect + 'gc> Clone for GcWeakCell<'gc, T> {
+    fn clone(&self) -> GcWeakCell<'gc, T> {
+        Self { inner: self.inner }
+    }
+}
+
+impl<'gc, T: 'gc + Collect> Debug for GcWeakCell<'gc, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "(GcWeakCell)")
+    }
+}
+
+unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
+    fn trace(&self, _cc: crate::CollectionContext) {
+        unsafe {
+            self.inner
+                .get_inner()
+                .ptr
+                .as_ref()
+                .flags
+                .set_has_weak_ref(true);
+        }
+    }
+}
+
+impl<'gc, T: Collect + 'gc> GcWeakCell<'gc, T> {
+    pub fn upgrade(&self) -> Option<GcCell<'gc, T>> {
+        unsafe {
+            self.inner
+                .get_inner()
+                .ptr
+                .as_ref()
+                .flags
+                .alive()
+                .then(|| self.inner)
+        }
+    }
+}

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -1,3 +1,4 @@
+use crate::types::GcColor;
 use crate::GcCell;
 use crate::{collect::Collect, MutationContext};
 
@@ -27,7 +28,9 @@ unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
             let gc = self.inner.get_inner().ptr.as_ref();
 
             gc.flags.set_has_weak_ref(true);
-            gc.flags.set_freshly_allocated(false);
+            if gc.flags.color() == GcColor::FreshWhite {
+                gc.flags.set_color(GcColor::White);
+            }
         }
     }
 }

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -11,7 +11,7 @@ impl<'gc, T: Collect + 'gc> Copy for GcWeakCell<'gc, T> {}
 
 impl<'gc, T: Collect + 'gc> Clone for GcWeakCell<'gc, T> {
     fn clone(&self) -> GcWeakCell<'gc, T> {
-        Self { inner: self.inner }
+        *self
     }
 }
 

--- a/src/gc-arena/src/gc_weak_cell.rs
+++ b/src/gc-arena/src/gc_weak_cell.rs
@@ -24,12 +24,10 @@ impl<'gc, T: 'gc + Collect> Debug for GcWeakCell<'gc, T> {
 unsafe impl<'gc, T: 'gc + Collect> Collect for GcWeakCell<'gc, T> {
     fn trace(&self, _cc: crate::CollectionContext) {
         unsafe {
-            self.inner
-                .get_inner()
-                .ptr
-                .as_ref()
-                .flags
-                .set_has_weak_ref(true);
+            let gc = self.inner.get_inner().ptr.as_ref();
+
+            gc.flags.set_has_weak_ref(true);
+            gc.flags.set_freshly_allocated(false);
         }
     }
 }

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -25,6 +25,7 @@ pub use self::{
     context::{CollectionContext, Context, MutationContext},
     gc::Gc,
     gc_cell::GcCell,
+    gc_weak::GcWeak,
     no_drop::MustNotImplDrop,
     static_collect::StaticCollect,
 };

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -15,6 +15,7 @@ mod context;
 mod gc;
 mod gc_cell;
 mod gc_weak;
+mod gc_weak_cell;
 mod no_drop;
 mod static_collect;
 mod types;
@@ -26,6 +27,7 @@ pub use self::{
     gc::Gc,
     gc_cell::GcCell,
     gc_weak::GcWeak,
+    gc_weak_cell::GcWeakCell,
     no_drop::MustNotImplDrop,
     static_collect::StaticCollect,
 };

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -14,6 +14,7 @@ mod collect_impl;
 mod context;
 mod gc;
 mod gc_cell;
+mod gc_weak;
 mod no_drop;
 mod static_collect;
 mod types;

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -13,7 +13,7 @@ pub(crate) enum GcColor {
 
 pub(crate) struct GcBox<T: Collect + ?Sized> {
     pub(crate) flags: GcFlags,
-    pub(crate) sweep_id: usize,
+    pub(crate) sweep_id: u64,
     pub(crate) next: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
     pub(crate) value: UnsafeCell<T>,
 }

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -13,6 +13,7 @@ pub(crate) enum GcColor {
 
 pub(crate) struct GcBox<T: Collect + ?Sized> {
     pub(crate) flags: GcFlags,
+    pub(crate) sweep_id: usize,
     pub(crate) next: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
     pub(crate) value: UnsafeCell<T>,
 }
@@ -66,11 +67,6 @@ impl GcFlags {
     }
 
     #[inline]
-    pub(crate) fn sweepable(&self) -> bool {
-        self.0.get() & 0x20 != 0x0
-    }
-
-    #[inline]
     pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
         self.0
             .set((self.0.get() & !0x4) | if needs_trace { 0x4 } else { 0x0 });
@@ -86,11 +82,6 @@ impl GcFlags {
     pub(crate) fn set_alive(&self, alive: bool) {
         self.0
             .set((self.0.get() & !0x10) | if alive { 0x10 } else { 0x0 });
-    }
-
-    pub(crate) fn set_sweepable(&self, sweepable: bool) {
-        self.0
-            .set((self.0.get() & !0x20) | if sweepable { 0x20 } else { 0x0 });
     }
 }
 

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -66,6 +66,11 @@ impl GcFlags {
     }
 
     #[inline]
+    pub(crate) fn sweepable(&self) -> bool {
+        self.0.get() & 0x20 != 0x0
+    }
+
+    #[inline]
     pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
         self.0
             .set((self.0.get() & !0x4) | if needs_trace { 0x4 } else { 0x0 });
@@ -81,6 +86,11 @@ impl GcFlags {
     pub(crate) fn set_alive(&self, alive: bool) {
         self.0
             .set((self.0.get() & !0x10) | if alive { 0x10 } else { 0x0 });
+    }
+
+    pub(crate) fn set_sweepable(&self, sweepable: bool) {
+        self.0
+            .set((self.0.get() & !0x20) | if sweepable { 0x20 } else { 0x0 });
     }
 }
 

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -66,7 +66,7 @@ impl GcFlags {
     }
 
     #[inline]
-    pub(crate) fn switch(&self) -> bool {
+    pub(crate) fn freshly_allocated(&self) -> bool {
         self.0.get() & 0x20 != 0x0
     }
 
@@ -89,9 +89,9 @@ impl GcFlags {
     }
 
     #[inline]
-    pub(crate) fn set_switch(&self, switch: bool) {
+    pub(crate) fn set_freshly_allocated(&self, freshly_allocated: bool) {
         self.0
-            .set((self.0.get() & !0x20) | if switch { 0x20 } else { 0x0 });
+            .set((self.0.get() & !0x20) | if freshly_allocated { 0x20 } else { 0x0 });
     }
 }
 

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -13,7 +13,6 @@ pub(crate) enum GcColor {
 
 pub(crate) struct GcBox<T: Collect + ?Sized> {
     pub(crate) flags: GcFlags,
-    pub(crate) sweep_id: u64,
     pub(crate) next: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
     pub(crate) value: UnsafeCell<T>,
 }
@@ -67,6 +66,11 @@ impl GcFlags {
     }
 
     #[inline]
+    pub(crate) fn switch(&self) -> bool {
+        self.0.get() & 0x20 != 0x0
+    }
+
+    #[inline]
     pub(crate) fn set_needs_trace(&self, needs_trace: bool) {
         self.0
             .set((self.0.get() & !0x4) | if needs_trace { 0x4 } else { 0x0 });
@@ -82,6 +86,12 @@ impl GcFlags {
     pub(crate) fn set_alive(&self, alive: bool) {
         self.0
             .set((self.0.get() & !0x10) | if alive { 0x10 } else { 0x0 });
+    }
+
+    #[inline]
+    pub(crate) fn set_switch(&self, switch: bool) {
+        self.0
+            .set((self.0.get() & !0x20) | if switch { 0x20 } else { 0x0 });
     }
 }
 

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -1,3 +1,4 @@
+use alloc::rc::Rc;
 use core::cell::{Cell, UnsafeCell};
 use core::marker::PhantomData;
 use core::ptr::NonNull;
@@ -13,6 +14,7 @@ pub(crate) enum GcColor {
 
 pub(crate) struct GcBox<T: Collect + ?Sized> {
     pub(crate) flags: GcFlags,
+    pub(crate) alive_flag: Option<Rc<Cell<bool>>>,
     pub(crate) next: Cell<Option<NonNull<GcBox<dyn Collect>>>>,
     pub(crate) value: UnsafeCell<T>,
 }

--- a/src/gc-arena/src/types.rs
+++ b/src/gc-arena/src/types.rs
@@ -62,7 +62,7 @@ impl GcFlags {
 
     #[inline]
     pub(crate) fn alive(&self) -> bool {
-        self.0.get() & 0x16 != 0x0
+        self.0.get() & 0x10 != 0x0
     }
 
     #[inline]
@@ -80,7 +80,7 @@ impl GcFlags {
     #[inline]
     pub(crate) fn set_alive(&self, alive: bool) {
         self.0
-            .set((self.0.get() & !0x16) | if alive { 0x16 } else { 0x0 });
+            .set((self.0.get() & !0x10) | if alive { 0x10 } else { 0x0 });
     }
 }
 

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -4,7 +4,7 @@ use rand::distributions::Distribution;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use gc_arena::{make_arena, unsafe_empty_collect, ArenaParameters, Collect, Gc, GcCell};
+use gc_arena::{make_arena, unsafe_empty_collect, ArenaParameters, Collect, Gc, GcCell, GcWeak};
 
 #[test]
 fn simple_allocation() {
@@ -22,6 +22,41 @@ fn simple_allocation() {
 
     arena.mutate(|_mc, root| {
         assert_eq!(*((*root).test), 42);
+    });
+}
+
+#[test]
+fn weak_allocation() {
+    #[derive(Collect)]
+    #[collect(no_drop)]
+    struct TestRoot<'gc> {
+        test: GcCell<'gc, Option<Gc<'gc, i32>>>,
+        weak: GcWeak<'gc, i32>,
+    }
+
+    make_arena!(TestArena, TestRoot);
+
+    let mut arena = TestArena::new(ArenaParameters::default(), |mc| {
+        let test = Gc::allocate(mc, 42);
+        let weak = Gc::downgrade(test);
+        TestRoot {
+            test: GcCell::allocate(mc, Some(test)),
+            weak,
+        }
+    });
+    arena.collect_all();
+    arena.mutate(|mc, root| {
+        assert!(root
+            .weak
+            .upgrade()
+            .map(|gc| Gc::ptr_eq(gc, root.test.read().unwrap()))
+            .unwrap_or(false));
+
+        *root.test.write(mc) = None;
+    });
+    arena.collect_all();
+    arena.mutate(|_mc, root| {
+        assert!((*root).weak.upgrade().is_none());
     });
 }
 

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -39,6 +39,7 @@ fn weak_allocation() {
     let mut arena = TestArena::new(ArenaParameters::default(), |mc| {
         let test = Gc::allocate(mc, 42);
         let weak = Gc::downgrade(test);
+        assert!(weak.upgrade(mc).is_some());
         TestRoot {
             test: GcCell::allocate(mc, Some(test)),
             weak,

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -48,15 +48,15 @@ fn weak_allocation() {
     arena.mutate(|mc, root| {
         assert!(root
             .weak
-            .upgrade()
+            .upgrade(mc)
             .map(|gc| Gc::ptr_eq(gc, root.test.read().unwrap()))
             .unwrap_or(false));
 
         *root.test.write(mc) = None;
     });
     arena.collect_all();
-    arena.mutate(|_mc, root| {
-        assert!((*root).weak.upgrade().is_none());
+    arena.mutate(|mc, root| {
+        assert!((*root).weak.upgrade(mc).is_none());
     });
 }
 


### PR DESCRIPTION
This is a weak pointer implementation for gc-arena.

The following API has been added:

- `Gc::downgrade` - Downgrades a Gc pointer to a `GcWeak`.
- `GcWeak::upgade` - Upgrades a GcWeak back to a Gc pointer if possible.
- `GcCell::downgrade` - Downgrades a GcCell to a `GcWeakCell`.
- `GcWeakCell::upgrade` - Upgrades a GcWeakCell back to a GcCell if possible.

One thing to keep in mind is that GcWeak::upgrade will work even if there are no more strong references to the allocation until the memory has actually been freed/in the process of being freed.