### PR TITLE
Implement static GC arenas

### DIFF
--- a/src/gc-arena/src/gc.rs
+++ b/src/gc-arena/src/gc.rs
@@ -73,4 +73,10 @@ impl<'gc, T: 'gc + Collect> Gc<'gc, T> {
     pub fn as_ptr(gc: Gc<'gc, T>) -> *const T {
         unsafe { gc.ptr.as_ref().value.get() }
     }
+
+    pub fn make_static(mc: MutationContext<'gc, '_>, gc: Gc<'gc, T>) {
+        unsafe {
+            mc.make_static(gc.ptr);
+        }
+    }
 }

--- a/src/gc-arena/src/gc_cell.rs
+++ b/src/gc-arena/src/gc_cell.rs
@@ -50,6 +50,10 @@ impl<'gc, T: 'gc + Collect> GcCell<'gc, T> {
         self.0.cell.as_ptr()
     }
 
+    pub fn make_static(mc: MutationContext<'gc, '_>, this: GcCell<'gc, T>) {
+        Gc::make_static(mc, this.0)
+    }
+
     #[track_caller]
     pub fn read<'a>(&'a self) -> Ref<'a, T> {
         self.0.cell.borrow()

--- a/src/gc-arena/src/gc_static.rs
+++ b/src/gc-arena/src/gc_static.rs
@@ -1,0 +1,54 @@
+#[macro_export]
+macro_rules! static_gc {
+    ($arena: ident, $typ: ty) => {
+        pub mod $arena {
+            use $crate::{Gc, GcCell};
+            #[derive(Debug)]
+            pub struct StaticArena<'gc> {
+                root: Gc<'gc, $typ>,
+                shared: std::rc::Rc<core::cell::RefCell<$crate::SharedGcData>>,
+            }
+
+            pub struct RootWrapper<'gc> {
+                root: Gc<'gc, $typ>,
+            }
+
+            impl<'gc> std::ops::Deref for RootWrapper<'gc> {
+                type Target = Gc<'gc, $typ>;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.root
+                }
+            }
+
+            impl<'gc> StaticArena<'gc> {
+                pub fn wrap(
+                    mc: $crate::MutationContext<'gc, '_>,
+                    root: $crate::Gc<'gc, $typ>,
+                ) -> StaticArena<'static> {
+                    unsafe {
+                        $crate::Gc::make_static(mc, root);
+                        let arena = Self {
+                            root,
+                            shared: mc.shared_data(),
+                        };
+                        std::mem::transmute(arena)
+                    }
+                }
+            }
+
+            impl StaticArena<'static> {
+                pub fn read(&self, f: impl for<'read> FnOnce(RootWrapper<'read>)) {
+                    assert!(self.shared.borrow().alive_flag);
+                    if !self.shared.borrow().read_lock {
+                        self.shared.borrow_mut().read_lock = true;
+                        f(RootWrapper { root: self.root });
+                        self.shared.borrow_mut().read_lock = false;
+                    } else {
+                        f(RootWrapper { root: self.root });
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/gc-arena/src/gc_static.rs
+++ b/src/gc-arena/src/gc_static.rs
@@ -9,18 +9,6 @@ macro_rules! static_gc {
                 shared: std::rc::Rc<core::cell::RefCell<$crate::SharedGcData>>,
             }
 
-            pub struct RootWrapper<'gc> {
-                root: Gc<'gc, $typ>,
-            }
-
-            impl<'gc> std::ops::Deref for RootWrapper<'gc> {
-                type Target = Gc<'gc, $typ>;
-
-                fn deref(&self) -> &Self::Target {
-                    &self.root
-                }
-            }
-
             impl<'gc> StaticArena<'gc> {
                 pub fn wrap(
                     mc: $crate::MutationContext<'gc, '_>,
@@ -38,14 +26,14 @@ macro_rules! static_gc {
             }
 
             impl StaticArena<'static> {
-                pub fn read(&self, f: impl for<'read> FnOnce(RootWrapper<'read>)) {
+                pub fn read(&self, f: impl for<'gc> FnOnce(Gc<'gc, $typ>)) {
                     assert!(self.shared.borrow().alive_flag);
                     if !self.shared.borrow().read_lock {
                         self.shared.borrow_mut().read_lock = true;
-                        f(RootWrapper { root: self.root });
+                        f(self.root);
                         self.shared.borrow_mut().read_lock = false;
                     } else {
-                        f(RootWrapper { root: self.root });
+                        f(self.root);
                     }
                 }
             }

--- a/src/gc-arena/src/gc_static.rs
+++ b/src/gc-arena/src/gc_static.rs
@@ -3,7 +3,7 @@ macro_rules! static_gc {
     ($arena: ident, $typ: ty) => {
         pub mod $arena {
             use $crate::{Gc, GcCell};
-            #[derive(Debug)]
+            #[derive(Debug, Clone)]
             pub struct StaticArena<'gc> {
                 root: Gc<'gc, $typ>,
                 shared: std::rc::Rc<core::cell::RefCell<$crate::SharedGcData>>,

--- a/src/gc-arena/src/gc_static_cell.rs
+++ b/src/gc-arena/src/gc_static_cell.rs
@@ -1,0 +1,54 @@
+#[macro_export]
+macro_rules! static_gc_cell {
+    ($arena: ident, $typ: ty) => {
+        pub mod $arena {
+            use $crate::{Gc, GcCell};
+            #[derive(Debug)]
+            pub struct StaticArena<'gc> {
+                root: GcCell<'gc, $typ>,
+                shared: std::rc::Rc<core::cell::RefCell<$crate::SharedGcData>>,
+            }
+
+            pub struct RootWrapper<'gc> {
+                root: GcCell<'gc, $typ>,
+            }
+
+            impl<'gc> std::ops::Deref for RootWrapper<'gc> {
+                type Target = GcCell<'gc, $typ>;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.root
+                }
+            }
+
+            impl<'gc> StaticArena<'gc> {
+                pub fn wrap(
+                    mc: $crate::MutationContext<'gc, '_>,
+                    root: $crate::GcCell<'gc, $typ>,
+                ) -> StaticArena<'static> {
+                    unsafe {
+                        $crate::GcCell::make_static(mc, root);
+                        let arena = Self {
+                            root,
+                            shared: mc.shared_data(),
+                        };
+                        std::mem::transmute(arena)
+                    }
+                }
+            }
+
+            impl StaticArena<'static> {
+                pub fn read(&self, f: impl for<'read> FnOnce(RootWrapper<'read>)) {
+                    assert!(self.shared.borrow().alive_flag);
+                    if !self.shared.borrow().read_lock {
+                        self.shared.borrow_mut().read_lock = true;
+                        f(RootWrapper { root: self.root });
+                        self.shared.borrow_mut().read_lock = false;
+                    } else {
+                        f(RootWrapper { root: self.root });
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/gc-arena/src/gc_static_cell.rs
+++ b/src/gc-arena/src/gc_static_cell.rs
@@ -3,7 +3,7 @@ macro_rules! static_gc_cell {
     ($arena: ident, $typ: ty) => {
         pub mod $arena {
             use $crate::{Gc, GcCell};
-            #[derive(Debug)]
+            #[derive(Debug, Clone)]
             pub struct StaticArena<'gc> {
                 root: GcCell<'gc, $typ>,
                 shared: std::rc::Rc<core::cell::RefCell<$crate::SharedGcData>>,

--- a/src/gc-arena/src/lib.rs
+++ b/src/gc-arena/src/lib.rs
@@ -14,6 +14,8 @@ mod collect_impl;
 mod context;
 mod gc;
 mod gc_cell;
+mod gc_static;
+mod gc_static_cell;
 mod no_drop;
 mod static_collect;
 mod types;
@@ -21,7 +23,7 @@ mod types;
 pub use self::{
     arena::{rootless_arena, ArenaParameters},
     collect::Collect,
-    context::{CollectionContext, Context, MutationContext},
+    context::{CollectionContext, Context, MutationContext, SharedGcData},
     gc::Gc,
     gc_cell::GcCell,
     no_drop::MustNotImplDrop,

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -51,7 +51,7 @@ fn static_gc() {
 
     if let Some(static_arena) = static_arena {
         static_arena.read(|root| {
-            assert_eq!(**root, 42);
+            assert_eq!(*root, 42);
         })
     }
 }
@@ -81,7 +81,7 @@ fn static_gc_early_drop() {
 
     if let Some(static_arena) = static_arena {
         static_arena.read(|root| {
-            assert_eq!(**root, 42);
+            assert_eq!(*root, 42);
         })
     }
 }
@@ -111,7 +111,7 @@ fn static_gc_mid_drop() {
     if let Some(static_arena) = static_arena {
         static_arena.read(|root| {
             drop(arena);
-            assert_eq!(**root, 42);
+            assert_eq!(*root, 42);
         })
     }
 }


### PR DESCRIPTION
A static GC arena gives us read-only access into a specific GC object in a regular GC arena. A static gc arena is not bounded by any lifetime, and can therefore be moved freely. A static GC arena can be read from using the `read` method, which uses the same lifetime mechanics as `arena::mutate` to guarantee no GC objects are smuggled out of the static arena. If a regular GC arena gets dropped and there are still static GC arenas with references to them, attempts to read from the dangling static GC arena will result in a panic. Similarly, if we are currently reading from a static GC arena and the regular GC arena gets dropped mid read, a panic will be triggered to prevent UB.

Also, it is impossible to call `GcCell::write` as the StaticArena will **never** give a MutationContext, which ensures complete immutability.

This PR accomplishes this using the `static_gc` macro, as well as the `static_gc_cell` macro. Here is an example on how to use them:
```rs
#[derive(Collect)]
#[collect(no_drop)]
struct TestRoot<'gc> {
    test: Gc<'gc, i32>,
}

make_arena!(TestArena, TestRoot);
// Creates a new StaticArena in a new module named `test_static` that references a Gc that contains an i32.
static_gc!(test_static, i32);

let mut arena = TestArena::new(ArenaParameters::default(), |mc| TestRoot {
    test: Gc::allocate(mc, 42),
});

let mut static_arena = None;

arena.mutate(|mc, root| {
    // Here we wrap the Gc<'gc, i32> in the StaticArena, which now becomes the root of the StaticArena.
    // Then, we move the static arena outside of the closure.
    static_arena = Some(test_static::StaticArena::wrap(mc, root.test.clone()));
});

if let Some(static_arena) = static_arena {
    // Now all we have to do is use the `read` method to access the object in our StaticArena.
    static_arena.read(|root| {
        assert_eq!(*root, 42);
    })
}
``` 