### PR TITLE
Remove mut requirement in the `mutate` method

### DIFF
--- a/src/gc-arena/src/arena.rs
+++ b/src/gc-arena/src/arena.rs
@@ -153,7 +153,7 @@ macro_rules! make_arena {
             /// during this call, but no garbage collection will take place during this method.
             #[allow(unused)]
             #[inline]
-            pub fn mutate<F, R>(&mut self, f: F) -> R
+            pub fn mutate<F, R>(&self, f: F) -> R
             where
                 F: for<'gc> FnOnce($crate::MutationContext<'gc, '_>, &$root<'gc>) -> R,
             {

--- a/src/gc-arena/tests/tests.rs
+++ b/src/gc-arena/tests/tests.rs
@@ -16,7 +16,7 @@ fn simple_allocation() {
 
     make_arena!(TestArena, TestRoot);
 
-    let mut arena = TestArena::new(ArenaParameters::default(), |mc| TestRoot {
+    let arena = TestArena::new(ArenaParameters::default(), |mc| TestRoot {
         test: Gc::allocate(mc, 42),
     });
 
@@ -87,7 +87,7 @@ fn all_dropped() {
 
     let r = RefCounter(Rc::new(()));
 
-    let mut arena = TestArena::new(ArenaParameters::default(), |mc| {
+    let arena = TestArena::new(ArenaParameters::default(), |mc| {
         TestRoot(GcCell::allocate(mc, Vec::new()))
     });
 


### PR DESCRIPTION
Makes calling the mutate method a little more flexible, will be helpful for some things i'm working on in Ruffle